### PR TITLE
Add Obtuse interface

### DIFF
--- a/src/main/java/com/poorlytrainedape/ontology/Obtuse.java
+++ b/src/main/java/com/poorlytrainedape/ontology/Obtuse.java
@@ -1,0 +1,9 @@
+package com.poorlytrainedape.ontology;
+
+/**
+ * Attempts to use the Java Reflection API on objects that implement Obtuse
+ * will always receive unhelpful--but technically true--type signatures.
+ */
+public interface Obtuse {
+
+}


### PR DESCRIPTION
Attempts to use the Java Reflection API on objects that implement Obtuse will always receive unhelpful--but technically true--type signatures.
